### PR TITLE
Speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Dependencies
 * numpy
 * scipy (for optimization)
 * fitsio - https://github.com/esheldon/fitsio
-
+* pyfftw - http://hgomersall.github.io/pyFFTW
 
 Install & Tests
 ---------------

--- a/ddtpy/fitting.py
+++ b/ddtpy/fitting.py
@@ -312,7 +312,7 @@ def fit_position_sn_sky_multi(galaxy, datas, weights, ctrs0, snctr0, atms):
     """
 
     BOUND = 2. # +/- position bound in spaxels
-    EPS = 0.01  # size of change in spaxels for gradient calculation
+    EPS = 0.001  # size of change in spaxels for gradient calculation
 
     nepochs = len(datas)
     assert len(weights) == len(ctrs0) == len(atms) == nepochs
@@ -376,6 +376,13 @@ def fit_position_sn_sky_multi(galaxy, datas, weights, ctrs0, snctr0, atms):
 
     fallctrs, f, d = fmin_l_bfgs_b(objective_func, allctrs0,
                                    iprint=0, callback=print, bounds=bounds)
+
+    print("optimization finished\n"
+          "function minimum: {:f}".format(f))
+    print("info dict: ")
+    for k, v in d.iteritems():
+        print(k, " : ", v)
+
 
     # pull out fitted positions
     fallctrs = fallctrs.reshape((nepochs+1, 2))

--- a/ddtpy/main.py
+++ b/ddtpy/main.py
@@ -163,7 +163,7 @@ def main(filename, data_dir):
         # make adr_refract[0, :] correspond to y and adr_refract[1, :] => x 
         adr_refract = np.flipud(adr_refract)
 
-        atms.append(AtmModel(psf, adr_refract))
+        atms.append(AtmModel(psf, adr_refract, fftw_threads=1))
 
     # -------------------------------------------------------------------------
     # Initialize all model parameters to be fit

--- a/ddtpy/model.py
+++ b/ddtpy/model.py
@@ -6,7 +6,7 @@ from numpy.fft import fft2, ifft2
 
 from .utils import fft_shift_phasor_2d
 
-__all__ = ["AtmModel", "AtmModelOld", "RegularizationPenalty"]
+__all__ = ["AtmModel", "RegularizationPenalty"]
 
 # -----------------------------------------------------------------------------
 # Helper functions

--- a/scripts/ddt-fit
+++ b/scripts/ddt-fit
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 parser = ArgumentParser(description="DDT: Datacube Deconvolution Thingy")
 parser.add_argument("filename", help="configuration file")
 parser.add_argument("data_dir", help="directory containing FITS data files")
-
+parser.add_argument("output_filename", help="Output filename")
 args = parser.parse_args()
 
-ddtpy.main(args.filename, args.data_dir)
+ddtpy.main(args.filename, args.data_dir, args.output_filename)

--- a/scripts/ddt-plot
+++ b/scripts/ddt-plot
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+import cPickle as pickle
+from argparse import ArgumentParser
 import ddtpy
 
-from argparse import ArgumentParser
-
-parser = ArgumentParser(description="DDT: Datacube Deconvolution Thingy")
-parser.add_argument("filename", help="configuration file")
-#parser.add_argument("data_dir", help="directory containing FITS data files")
-
+parser = ArgumentParser(description="ddt-plot")
+parser.add_argument("result_filename",
+                    help="output from ddt-fit (.pkl file)")
+parser.add_argument("figure_filename", help="target filename")
 args = parser.parse_args()
 
-ddtpy.plot_all(args.filename)
+f = open(args.result_filename, 'rb')
+result_dict = pickle.load(f)
+f.close()
+
+ddtpy.plot_timeseries(result_dict, fname=args.figure_filename)

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(name="ddtpy",
       author_email="kylebarbary@gmail.com",
       requires=['numpy', 'scipy'],
       packages=['ddtpy'],
-      scripts=['scripts/ddt-fit','scripts/ddt_gal_sub'],
+      scripts=['scripts/ddt-fit','scripts/ddt-plot'],
       data_files=data_files)


### PR DESCRIPTION
This changes most (but not yet all) of our FFT operations to use PyFFTW. With this change, I see speed boosts of a factor of 6+ in both `atm.evaluate_galaxy()` and `atm.evaluate_point_source()`. Total runtime is about 4 min. Profiling shows that the main steps take the following amount of time:

- `fit_galaxy_single`: 5s
- `fit_galaxy_multi`: 13s
- `fit_position_sn_sky_multi`: 222s (89%)

The final step just takes a really long time to converge (14 iterations, ~150 function calls), much more than the `fit_galaxy_*` functions. Also, the final gradient and chisq don't look very good. Maybe l_bfgs_b is not a good optimizer for this part of the problem? Or more probably there's probably a bug...